### PR TITLE
Give feedback for the best target recipe

### DIFF
--- a/static/recipe.js
+++ b/static/recipe.js
@@ -25,7 +25,7 @@ class Recipe {
 		const scoredFeedbackOptions = [];
 		for (let recipe of targetRecipes)
 			scoredFeedbackOptions.push(recipe.score());
-		scoredFeedbackOptions.sort((a, b) => a[0] < b[0]);
+		scoredFeedbackOptions.sort((a, b) => b[0] - a[0]);
 		return scoredFeedbackOptions[0][1];
 	}
 


### PR DESCRIPTION
Feedback for different recipes for the same target wasn't being sorted
correctly, so it was always based upon the first target recipe.


This bug makes today's puzzle appear impossible - if you use the shaped recipe for a different banner, then you currently receive feedback with two green positions in the bottom row, when the entire bottom row ought to be green.